### PR TITLE
CC-89808 Rebrand AWS CLI plugin to CyberArk Identity & Update AWSCLI.…

### DIFF
--- a/AWS CLI - Idaptive V1/AWSCLI.py
+++ b/AWS CLI - Idaptive V1/AWSCLI.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,9 @@ def get_environment(args):
         tenant = tenant + ".centrify.com"
     name = tenant.split(".")[0]
     tenant = "https://" + tenant
-    cert = "cacerts_" + name + ".pem"
+    cert = True
+    # Users can uncommment the following line and comment the line "cert=True" if they want cert pinning.
+    # cert = "cacerts_" + name + ".pem"
     debug = args.debug
     env = environment.Environment(name, tenant, cert, debug)
     return env

--- a/AWS CLI - Idaptive V1/LICENSE.md
+++ b/AWS CLI - Idaptive V1/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2019 IDaptive, LLC.
+Copyright 2019 CyberArk, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/AWS CLI - Idaptive V1/README.md
+++ b/AWS CLI - Idaptive V1/README.md
@@ -1,1 +1,1 @@
-Please see https://developer.idaptive.com/v1.2/docs/aws-cli
+Please see https://identity-developer.cyberark.com/docs/aws-cli

--- a/AWS CLI - Idaptive V1/aws/__init__.py
+++ b/AWS CLI - Idaptive V1/aws/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/aws/assumerolesaml.py
+++ b/AWS CLI - Idaptive V1/aws/assumerolesaml.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/config/__init__.py
+++ b/AWS CLI - Idaptive V1/config/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/config/apps.py
+++ b/AWS CLI - Idaptive V1/config/apps.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/config/environment.py
+++ b/AWS CLI - Idaptive V1/config/environment.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/config/proxy.py
+++ b/AWS CLI - Idaptive V1/config/proxy.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/config/readconfig.py
+++ b/AWS CLI - Idaptive V1/config/readconfig.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/adv_authrequest.py
+++ b/AWS CLI - Idaptive V1/core/adv_authrequest.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/auth.py
+++ b/AWS CLI - Idaptive V1/core/auth.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/authrequest.py
+++ b/AWS CLI - Idaptive V1/core/authrequest.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/authresponse.py
+++ b/AWS CLI - Idaptive V1/core/authresponse.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/authsession.py
+++ b/AWS CLI - Idaptive V1/core/authsession.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/awsinputs.py
+++ b/AWS CLI - Idaptive V1/core/awsinputs.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/htmlparser.py
+++ b/AWS CLI - Idaptive V1/core/htmlparser.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/htmlresponse.py
+++ b/AWS CLI - Idaptive V1/core/htmlresponse.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/restclient.py
+++ b/AWS CLI - Idaptive V1/core/restclient.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/samlapp.py
+++ b/AWS CLI - Idaptive V1/core/samlapp.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/uprest.py
+++ b/AWS CLI - Idaptive V1/core/uprest.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/user.py
+++ b/AWS CLI - Idaptive V1/core/user.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/core/util.py
+++ b/AWS CLI - Idaptive V1/core/util.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/kbread/__init__.py
+++ b/AWS CLI - Idaptive V1/kbread/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS CLI - Idaptive V1/kbread/kbinput.py
+++ b/AWS CLI - Idaptive V1/kbread/kbinput.py
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS Powershell - Idaptive v1/AWS.SSO.Powershell.psm1
+++ b/AWS Powershell - Idaptive v1/AWS.SSO.Powershell.psm1
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS Powershell - Idaptive v1/Authenticate.ps1
+++ b/AWS Powershell - Idaptive v1/Authenticate.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright 2019 IDaptive, LLC.
+﻿# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS Powershell - Idaptive v1/Init.psm1
+++ b/AWS Powershell - Idaptive v1/Init.psm1
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS Powershell - Idaptive v1/LICENSE.md
+++ b/AWS Powershell - Idaptive v1/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2019 IDaptive, LLC.
+Copyright 2019 CyberArk, LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/AWS Powershell - Idaptive v1/PowerShell.REST.psm1
+++ b/AWS Powershell - Idaptive v1/PowerShell.REST.psm1
@@ -1,4 +1,4 @@
-# Copyright 2019 IDaptive, LLC.
+# Copyright 2019 CyberArk, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AWS Powershell - Idaptive v1/README.md
+++ b/AWS Powershell - Idaptive v1/README.md
@@ -1,1 +1,1 @@
-Please see https://developer.idaptive.com/docs/aws-powershell-utility-v10
+Please see https://identity-developer.cyberark.com/docs/aws-powershell-utility-v10

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # aws-cli-utilities
-AWS CLI tools for Idaptive
+AWS CLI tools for CyberArk


### PR DESCRIPTION
Root cause: Branding for AWS CLI is set to Idaptive which should be CyberArk now.

Reason for regression: N/A

Resolution:
	Rebranding work for Idaptive to CyberArk.

GUI Changes: N/A

Security Review: N/A

Manual Code Validation (Step Through):

New Unit Tests: N/A

Unit Test Results: N/A

Jira URL:
	https://ca-il-jira.il.cyber-ark.com:8443/browse/CC-89808

Steps to reproduce:

Notes to QA:

Smoketest Results: N/A

Files affected: