### PR TITLE
CC-112031 Identity CLI getting issue to identify tenant in the produc…

### DIFF
--- a/AWS CLI - Idaptive V1/AWSCLI.py
+++ b/AWS CLI - Idaptive V1/AWSCLI.py
@@ -27,7 +27,7 @@ import traceback
 
 def get_environment(args):
     tenant = args.tenant
-    if ("idaptive." not in tenant):
+    if ("." not in tenant):
         tenant = tenant + ".idaptive.app"
     name = tenant.split(".")[0]
     tenant = "https://" + tenant


### PR DESCRIPTION
…tion

Root cause:
As production environments domain changed and adding 'idaptive.app' to the tenant if 'idaptive.app' not exist , getting issue while
launch AWS console from cli

Reason for regression:
"N/A"

Resolution:
Removed code to append 'idaptive.app' if not exist in the tenant

GUI Changes:
"N/A"

Security Review:

Manual Code Validation (Step Through):

New Unit Tests:
"N/A"

Unit Test Results:
"N/A"

Jira URL:
https://ca-il-jira.il.cyber-ark.com:8443/browse/CC-112031

Steps to reproduce:
"See above Jira"

Notes to QA:
"N/A"

Smoketest Results:
"N/A"

Files affected:
AWSCLI.py file has modified